### PR TITLE
Active Trip Query

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -24,8 +24,12 @@ module Types
       EmergencyContact.find(id)
     end
 
-    field :trips, [Types::TripType], null: true do
-      description "Get all Trips"
+    field :active_trips, [Types::TripType], null: true do
+      description "Get all active trips past notification time"
+    end
+
+    def active_trips
+      Trip.where('notification_time < ? AND notification_date <= ? AND active = ?', Time.current, Date.current, true)
     end
 
     field :trip, Types::TripType, null: true do
@@ -71,7 +75,7 @@ module Types
     def trip_gears
       TripGear.all
     end
-    
+
     field :teams, [Types::SearchAndRescueType], null: false
     #Gets all search and rescue teams
     def teams

--- a/db/migrate/20191020213932_create_trips.rb
+++ b/db/migrate/20191020213932_create_trips.rb
@@ -5,11 +5,11 @@ class CreateTrips < ActiveRecord::Migration[5.2]
       t.string :starting_point
       t.string :ending_point
       t.date :start_date
-      t.time :start_time
+      t.datetime :start_time
       t.date :end_date
-      t.time :end_time
+      t.datetime :end_time
       t.date :notification_date
-      t.time :notification_time
+      t.datetime :notification_time
       t.integer :traveling_companions
       t.references :user, foreign_key: true
 

--- a/db/migrate/20191026215624_add_active_to_trip.rb
+++ b/db/migrate/20191026215624_add_active_to_trip.rb
@@ -1,0 +1,5 @@
+class AddActiveToTrip < ActiveRecord::Migration[5.2]
+  def change
+    add_column :trips, :active, :boolean, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_26_202653) do
+ActiveRecord::Schema.define(version: 2019_10_26_215624) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,16 +69,17 @@ ActiveRecord::Schema.define(version: 2019_10_26_202653) do
     t.string "starting_point"
     t.string "ending_point"
     t.date "start_date"
-    t.time "start_time"
+    t.datetime "start_time"
     t.date "end_date"
-    t.time "end_time"
+    t.datetime "end_time"
     t.date "notification_date"
-    t.time "notification_time"
+    t.datetime "notification_time"
     t.integer "traveling_companions"
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "activity_type"
+    t.boolean "active", default: false
     t.index ["user_id"], name: "index_trips_on_user_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -57,10 +57,11 @@ end
     start_time: start_date,
     end_date: end_date,
     end_time: end_date,
-    notification_date: end_date + 1,
-    notification_time: end_date + 1 ,
+    notification_date: end_date + 1.day,
+    notification_time: end_date + 1.hour,
     traveling_companions: rand(1..2),
-    user_id: User.find(User.pluck(:id).sample).id
+    user_id: User.find(User.pluck(:id).sample).id,
+    active: Faker::Boolean.boolean
   )
   user = User.find(trip.user_id)
   contact = user.emergency_contacts.sample
@@ -77,5 +78,25 @@ end
     trip_id: Trip.find(Trip.pluck(:id).sample).id,
     gear_id: item.id,
     comments: Faker::ChuckNorris.fact
+  )
+end
+
+# Users that have not "checked in"
+2.times do
+  name = Faker::Company.name
+  Trip.create(
+    name: name,
+    activity_type: Faker::Job.key_skill,
+    starting_point: name,
+    ending_point: Faker::Company.name,
+    start_date: Date.current - 1.day,
+    start_time: Time.current - 12.hours,
+    end_date: Date.current,
+    end_time: Time.current - 6.hours,
+    notification_date: Date.current,
+    notification_time: Time.current - 2.hours,
+    traveling_companions: rand(1..2),
+    user_id: User.find(User.pluck(:id).sample).id,
+    active: true
   )
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     phone { Faker::PhoneNumber.unique.cell_phone }
     email { Faker::Internet.unique.email(name: name) }
     password_digest { Faker::Alphanumeric.unique.alphanumeric(number: 30) }
-    allergies { Faker::Food.unique.fruits }
+    allergies { Faker::Food.fruits }
     experience_level { rand(0...2) }
     birth_date { Faker::Date.between(from: 60.years.ago, to: 18.years.ago) }
     weight { rand(100..300) }

--- a/spec/graphql/types/queries/trip_query_type_spec.rb
+++ b/spec/graphql/types/queries/trip_query_type_spec.rb
@@ -30,5 +30,40 @@ RSpec.describe Types::QueryType do
       trip = SearchAndRescueApiSchema.execute(query).as_json['data']['trip']
       expect(trip['name']).to eq(trip_1.name)
     end
+
+    it "should return a trip that has not checked in and is past notification time" do
+      user = create(:user)
+      20.times do
+        create(:trip)
+      end
+      trip = Trip.create(
+        name: "Maroon Bells",
+        activity_type: Faker::Job.key_skill,
+        starting_point: "Maroon Bells Trailhead",
+        ending_point: Faker::Company.name,
+        start_date: Date.current - 1.day,
+        start_time: Time.current - 12.hours,
+        end_date: Date.current,
+        end_time: Time.current - 6.hours,
+        notification_date: Date.current,
+        notification_time: Time.current - 2.hours,
+        traveling_companions: rand(1..2),
+        user_id: user.id,
+        active: true
+      )
+      query = (
+        %(query {
+          activeTrips {
+            name
+            user {
+              name
+            }
+          }
+        })
+      )
+      results = SearchAndRescueApiSchema.execute(query).as_json['data']['activeTrips']
+      expect(results[0]['name']).to eq(trip.name)
+      expect(results[0]['user']['name']).to eq(user.name)
+    end
   end
 end

--- a/spec/graphql/types/queries/trip_query_type_spec.rb
+++ b/spec/graphql/types/queries/trip_query_type_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe Types::QueryType do
         })
       )
       results = SearchAndRescueApiSchema.execute(query).as_json['data']['activeTrips']
+      expect(results.length).to eq(1)
       expect(results[0]['name']).to eq(trip.name)
       expect(results[0]['user']['name']).to eq(user.name)
     end

--- a/spec/requests/trip_request_spec.rb
+++ b/spec/requests/trip_request_spec.rb
@@ -83,4 +83,39 @@ describe "User's Trips'" do
 
     expect(response).to be_successful
   end
+
+  it "returns trips that are active and not checked in" do
+    trip = Trip.create(
+      name: "Maroon Bells",
+      activity_type: Faker::Job.key_skill,
+      starting_point: "Maroon Bells Trailhead",
+      ending_point: Faker::Company.name,
+      start_date: Date.current - 1.day,
+      start_time: Time.current - 12.hours,
+      end_date: Date.current,
+      end_time: Time.current - 6.hours,
+      notification_date: Date.current,
+      notification_time: Time.current - 2.hours,
+      traveling_companions: rand(1..2),
+      user_id: @user.id,
+      active: true
+    )
+    query = (
+      %(query {
+        activeTrips {
+          name
+          user {
+            name
+          }
+        }
+      })
+    )
+    post "/graphql", params: { "query" => query }.to_json, headers: { 'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json' }
+    results = JSON.parse(response.body, symbolize_names: true)[:data][:activeTrips]
+
+    expect(response).to be_successful
+    expect(results.length).to eq(1)
+    expect(results[0][:name]).to eq(trip.name)
+    expect(results[0][:user][:name]).to eq(@user.name)
+  end
 end


### PR DESCRIPTION
- Create migration to add 'Active' boolean attribute to Trip
- Create query and request tests for active trips
- Add query to find trips that have not checked in and are past notification time
- Add seed for trips that are active and not checked in (past notification time)

- [x] All tests passing